### PR TITLE
Minor fixes

### DIFF
--- a/aniMeta.py
+++ b/aniMeta.py
@@ -55,6 +55,8 @@ from shiboken2 import wrapInstance
 
 from functools import partial
 
+px = omui.MQtUtil.dpiScale
+
 kPluginName    = 'aniMeta'
 kPluginVersion = '01.00.127'
 
@@ -11470,8 +11472,8 @@ class AniMetaUI( MayaQWidgetDockableMixin, QWidget):
         }
 
         refreshButton = QPushButton("Refresh", self)
-        refreshButton.setFixedWidth(72)
-        refreshButton.setFixedHeight(32)
+        refreshButton.setFixedWidth(px(72))
+        refreshButton.setFixedHeight(px(32))
         refreshButton.setStyleSheet(
             "QPushButton {background-color: #666666; border-radius: 3px;}"
             "QPushButton:hover {background-color: #777777; }"
@@ -11755,7 +11757,7 @@ class MainTab( QWidget ):
 
     def __options__( self ):
 
-        self.button_sizes   = { 'X-Small': 16, 'Small': 20, 'Medium': 24, 'Large': 28, 'X-Large': 32 }
+        self.button_sizes   = { 'X-Small': px(16), 'Small': px(20), 'Medium': px(24), 'Large': px(28), 'X-Large': px(32) }
         self.button_sizes_names = ( 'X-Small', 'Small', 'Medium', 'Large', 'X-Large' )
         if not mc.optionVar( exists = 'aniMetaUIButtonSize' ):
             mc.optionVar( sv = [ 'aniMetaUIButtonSize', 'Medium' ] )
@@ -11794,7 +11796,7 @@ class MainTab( QWidget ):
 
         ########################################
         #   Create
-        row_height = 48
+        row_height = px(48)
 
         frame1 = FrameWidget('Create', None,  row_height*2   )
         frames_layout.addWidget(frame1)

--- a/aniMeta.py
+++ b/aniMeta.py
@@ -126,6 +126,8 @@ class AniMeta( object ):
         self.check_folder( self.folder_anim )
         self.check_folder( self.folder_rig )
 
+        # Required plug-in that may or may not already be loaded
+        mc.loadPlugin("mayaHIK", quiet=True)
 
     def check_folder (self, folder):
 


### PR DESCRIPTION
Hello!

Stumbled upon some minor issues with a DPI scaled Maya UI, I believe the `After` is the intended appearance.

| Before | After
|:---|:----
| ![image](https://user-images.githubusercontent.com/2152766/149015612-3adefd89-9124-4ff4-9bfa-679aa5095bd0.png)  | ![image](https://user-images.githubusercontent.com/2152766/149015544-472abba7-f06c-4b3d-b179-c6ecb6c8c9b5.png)

The way I deal with this personally is by wrapping any pixel value, such as `setFixedWidth(10)` in a conversion function, such as `MQtUtil.dpiScale`. For brevity, I typically call this function `px` such that we end up with something readable, that is appropriately sized at any scale.

```py
widget.setFixedWidth(px(10))
```

There are probably one or more pixel values I've missed, and I spotted a few embedded in stylesheets as well. Those will need wrapping as well for a fully scalable UI.

I've also added an auto-load of a plug-in that was assumed to be loaded when generating the control rig, namely `mayaHIK`. I was planning on adding more commits to this if/as I stumble upon more things. Generating a larger pull-request.

Unless you prefer smaller pull-request? In which case I can leave this as-is, and continue on another branch.